### PR TITLE
Update to Blender 2.81+, and more

### DIFF
--- a/render_alb.py
+++ b/render_alb.py
@@ -22,9 +22,9 @@ import string
 
 def select_object(ob):
     bpy.ops.object.select_all(action='DESELECT')
-    bpy.context.scene.objects.active = None
-    ob.select=True
-    bpy.context.scene.objects.active = ob
+    bpy.context.view_layer.objects.active = None
+    ob.select_set(True)
+    bpy.context.view_layer.objects.active = ob
 
 
 def prepare_rendersettings():
@@ -45,8 +45,7 @@ def render():
 
 
 def get_albedo_img(img_name):
-    scene=bpy.data.scenes['Scene']
-    scene.render.layers['RenderLayer'].use_pass_diffuse_color=True
+    bpy.context.view_layer.use_pass_diffuse_color=True
     bpy.context.scene.use_nodes = True
     tree = bpy.context.scene.node_tree
     links = tree.links
@@ -67,13 +66,13 @@ def get_albedo_img(img_name):
 	
     file_output_node.base_path = out_path
     file_output_node.file_slots[0].path = img_name
-    links.new(render_layers.outputs[21], file_output_node.inputs[0])
-    links.new(render_layers.outputs[21], comp_node.inputs[0])
+    links.new(render_layers.outputs['DiffCol'], file_output_node.inputs[0])
+    links.new(render_layers.outputs['DiffCol'], comp_node.inputs[0])
 
 def prepare_no_env_render():
     # Remove lamp
-    for lamp in bpy.data.lamps:
-        bpy.data.lamps.remove(lamp, do_unlink=True)
+    for lamp in bpy.data.lights:
+        bpy.data.lights.remove(lamp, do_unlink=True)
 
     world=bpy.data.worlds['World']
     world.use_nodes = True
@@ -82,7 +81,7 @@ def prepare_no_env_render():
     for l in links:
         links.remove(l)
     scene=bpy.data.scenes['Scene']
-    scene.view_settings.view_transform='Default'
+    scene.view_settings.view_transform='Standard'
 
 
 rridx=sys.argv[-3]

--- a/render_alb.py
+++ b/render_alb.py
@@ -19,6 +19,7 @@ import random
 import math
 from mathutils import Vector, Euler
 import string
+from pathlib import Path
 
 def select_object(ob):
     bpy.ops.object.select_all(action='DESELECT')
@@ -87,7 +88,7 @@ def prepare_no_env_render():
 rridx=sys.argv[-3]
 strt=int(sys.argv[-2])
 end=int(sys.argv[-1])
-path_to_output_alb = './alb/'+ str(rridx) + '/'
+path_to_output_alb = os.path.abspath('./alb/'+ str(rridx) + '/')
 blend_list = './blendlists/blendlist'+ str(rridx) +'.csv'
 
 if not os.path.exists(path_to_output_alb):
@@ -98,7 +99,7 @@ with open(blend_list,'r') as b:
 
 for bfile in blendlist[strt:end]:
     bfname=bfile[0]
-    fn=bfname.split('/')[-1][:-6]
+    fn=Path(bfname).stem
     #load blend file 
     bpy.ops.wm.open_mainfile(filepath=bfname)
     prepare_rendersettings()

--- a/render_dmap.py
+++ b/render_dmap.py
@@ -22,9 +22,9 @@ import string
 
 def select_object(ob):
     bpy.ops.object.select_all(action='DESELECT')
-    bpy.context.scene.objects.active = None
-    ob.select=True
-    bpy.context.scene.objects.active = ob
+    bpy.context.view_layer.objects.active = None
+    ob.select_set(True)
+    bpy.context.view_layer.objects.active = ob
 
 
 def render():
@@ -38,8 +38,8 @@ def render():
 
 def prepare_no_env_render():
     # Remove lamp
-    for lamp in bpy.data.lamps:
-        bpy.data.lamps.remove(lamp, do_unlink=True)
+    for lamp in bpy.data.lights:
+        bpy.data.lights.remove(lamp, do_unlink=True)
 
     world=bpy.data.worlds['World']
     world.use_nodes = True
@@ -50,7 +50,7 @@ def prepare_no_env_render():
     scene=bpy.data.scenes['Scene']
     scene.cycles.samples=1
     scene.cycles.use_square_samples=True
-    scene.view_settings.view_transform='Default'
+    scene.view_settings.view_transform='Standard'
 
 
 def get_depth_map(img_name):
@@ -72,7 +72,7 @@ def get_depth_map(img_name):
     file_output_node.base_path = path_to_output_dmap
     file_output_node.file_slots[0].path = img_name
 
-    links.new(render_layers.outputs[2], file_output_node.inputs[0])    
+    links.new(render_layers.outputs['Depth'], file_output_node.inputs[0])    
 
 
 

--- a/render_dmap.py
+++ b/render_dmap.py
@@ -18,6 +18,7 @@ import bmesh
 import random
 import math
 import string
+from pathlib import Path
 
 
 def select_object(ob):
@@ -79,7 +80,7 @@ def get_depth_map(img_name):
 strt=int(sys.argv[-2])
 end=int(sys.argv[-1])
 rridx=sys.argv[-3]
-path_to_output_dmap = './dmap/{}/'.format(rridx)
+path_to_output_dmap = os.path.abspath('./dmap/{}/'.format(rridx))
 blend_list = './blendlists/blendlist{}.csv'.format(rridx)
 
 if not os.path.exists(path_to_output_dmap):
@@ -92,7 +93,7 @@ with open(blend_list,'r') as b:
 for bfile in blendlist[strt:end]:
     bpy.ops.wm.read_factory_settings()
     bfname=bfile[0]
-    fn=bfname.split('/')[-1][:-6]
+    fn=Path(bfname).stem
     bpy.ops.wm.open_mainfile(filepath=bfname)
     get_depth_map(fn)  
     render()

--- a/render_mesh.py
+++ b/render_mesh.py
@@ -472,7 +472,7 @@ with open(tex_list, 'r') as t, open(obj_list, 'r') as m:
     for k in range(id1, id2):
         #print(k)
         objpath = objlist[k][0]
-        idx = random.randint(0, len(texlist))
+        idx = random.randrange(0, len(texlist))
         texpath=texlist[idx][0]
         print(objpath)
         print(texpath)

--- a/render_mesh.py
+++ b/render_mesh.py
@@ -5,7 +5,7 @@ https://www3.cs.stonybrook.edu/~cvl/projects/dewarpnet/storage/paper.pdf (ICCV 2
 This code renders the gts needed for the DewarpNet training (image, uv, 3D coordinates) 
 and saves the .blend files. The .blend files can be later used 
 to render other gts (normal, depth, checkerboard, albedo). 
-Each .blend file takes ~2.5MB set the save_blend_file flag to False if you don't need.
+Each .blend file takes ~0.7MB. Set the save_blend_file flag to False if you don't need.
 
 Written by: Sagnik Das and Ke Ma
 Stony Brook University, New York
@@ -396,7 +396,8 @@ def render_pass(obj, objpath, texpath):
 
     # save_blend_file
     if save_blend_file:
-        bpy.ops.wm.save_mainfile(filepath=os.path.join(path_to_output_blends, fn+'.blend'))
+        bpy.ops.wm.save_mainfile(filepath=os.path.join(path_to_output_blends, fn+'.blend'),
+            compress=True)
 
     # prepare to render without environment
     prepare_no_env_render()

--- a/render_norm.py
+++ b/render_norm.py
@@ -20,6 +20,7 @@ import random
 import math
 from mathutils import Vector, Euler
 import string
+from pathlib import Path
 
 
 def select_object(ob):
@@ -111,7 +112,7 @@ end=int(sys.argv[-1])
 rridx=sys.argv[-3]
 
 blend_list = './blendlists/blendlist{}.csv'.format(rridx)
-path_to_output_norms= './norm/{}/'.format(rridx)
+path_to_output_norms= os.path.abspath('./norm/{}/'.format(rridx))
 
 if not os.path.exists(path_to_output_norms):
     os.makedirs(path_to_output_norms)
@@ -125,7 +126,7 @@ for bfile in blendlist[strt:end]:
     bfname=bfile[0]
     #load blend file 
     bpy.ops.wm.open_mainfile(filepath=bfname)
-    fn=bfname.split('/')[-1][:-6]
+    fn=Path(bfname).stem
     mesh=bpy.data.objects[bpy.data.meshes[0].name]
 
     # render world coordinates

--- a/render_norm.py
+++ b/render_norm.py
@@ -24,9 +24,9 @@ import string
 
 def select_object(ob):
     bpy.ops.object.select_all(action='DESELECT')
-    bpy.context.scene.objects.active = None
-    ob.select=True
-    bpy.context.scene.objects.active = ob
+    bpy.context.view_layer.objects.active = None
+    ob.select_set(True)
+    bpy.context.view_layer.objects.active = ob
 
 
 def render():
@@ -39,8 +39,8 @@ def render():
 
 def color_norm_material(obj,mat_name):
     # Remove lamp
-    for lamp in bpy.data.lamps:
-        bpy.data.lamps.remove(lamp, do_unlink=True)
+    for lamp in bpy.data.lights:
+        bpy.data.lights.remove(lamp, do_unlink=True)
 
     select_object(obj)
     # Add a new material
@@ -90,8 +90,8 @@ def get_normal_img(img_name):
 
 def prepare_no_env_render():
     # Remove lamp
-    for lamp in bpy.data.lamps:
-        bpy.data.lamps.remove(lamp, do_unlink=True)
+    for lamp in bpy.data.lights:
+        bpy.data.lights.remove(lamp, do_unlink=True)
 
     world=bpy.data.worlds['World']
     world.use_nodes = True
@@ -102,7 +102,7 @@ def prepare_no_env_render():
     scene=bpy.data.scenes['Scene']
     scene.cycles.samples=1
     scene.cycles.use_square_samples=True
-    scene.view_settings.view_transform='Default'
+    scene.view_settings.view_transform='Standard'
 
 
 # read args

--- a/render_recon.py
+++ b/render_recon.py
@@ -19,6 +19,7 @@ import random
 import math
 from mathutils import Vector, Euler
 import string
+from pathlib import Path
 
 
 def select_object(ob):
@@ -111,7 +112,7 @@ def prepare_no_env_render():
     scene=bpy.data.scenes['Scene']
     scene.cycles.samples=1
     scene.cycles.use_square_samples=True
-    scene.view_settings.view_transform='Default'
+    scene.view_settings.view_transform='Standard'
 
 
 
@@ -120,8 +121,8 @@ strt=int(sys.argv[-2])
 end=int(sys.argv[-1])
 
 blend_list = './blendlists/blendlist{}.csv'.format(rridx)
-texpath = './recon_tex/chess48.png'
-path_to_output_alb = './recon/{}/'.format(rridx)
+texpath = os.path.abspath('./recon_tex/chess48.png')
+path_to_output_alb = os.path.abspath('./recon/{}/'.format(rridx))
 
 if not os.path.exists(path_to_output_alb):
     os.makedirs(path_to_output_alb)
@@ -134,9 +135,9 @@ for bfile in blendlist[strt:end]:
     #load blend file 
     bpy.ops.wm.open_mainfile(filepath=bfname)
 
-    texname=texpath.split('/')[-1][:-4]
+    texname=Path(texpath).stem
     render_img_newtex(texpath)
-    fn=bfname.split('/')[-1][:-6]+texname
+    fn=Path(bfname).stem+texname
     if os.path.isfile(os.path.join(path_to_output_alb,fn+'0001.png')):
         continue
     prepare_no_env_render()

--- a/render_recon.py
+++ b/render_recon.py
@@ -23,9 +23,9 @@ import string
 
 def select_object(ob):
     bpy.ops.object.select_all(action='DESELECT')
-    bpy.context.scene.objects.active = None
-    ob.select=True
-    bpy.context.scene.objects.active = ob
+    bpy.context.view_layer.objects.active = None
+    ob.select_set(True)
+    bpy.context.view_layer.objects.active = ob
 
 
 def render_img_newtex(texpath):
@@ -74,8 +74,7 @@ def render():
 
 
 def get_albedo_img(img_name,texname):
-    scene=bpy.data.scenes['Scene']
-    scene.render.layers['RenderLayer'].use_pass_diffuse_color=True
+    bpy.context.view_layer.use_pass_diffuse_color=True
     bpy.context.scene.use_nodes = True
     tree = bpy.context.scene.node_tree
     links = tree.links
@@ -95,13 +94,13 @@ def get_albedo_img(img_name,texname):
 	
     file_output_node.base_path = out_path
     file_output_node.file_slots[0].path = img_name
-    links.new(render_layers.outputs[21], file_output_node.inputs[0])
-    links.new(render_layers.outputs[21], comp_node.inputs[0])
+    links.new(render_layers.outputs['DiffCol'], file_output_node.inputs[0])
+    links.new(render_layers.outputs['DiffCol'], comp_node.inputs[0])
 
 def prepare_no_env_render():
     # Remove lamp
-    for lamp in bpy.data.lamps:
-        bpy.data.lamps.remove(lamp, do_unlink=True)
+    for lamp in bpy.data.lights:
+        bpy.data.lights.remove(lamp, do_unlink=True)
 
     world=bpy.data.worlds['World']
     world.use_nodes = True


### PR DESCRIPTION
- Adapt to Blender 2.80 and 2.81 changes. Tested with versions 2.93 LTS and 3.0.
  - Note: I compared the resulting "extra" images (albedos, etc.) from 2.79 and 3.0, and while there is no obvious visual difference, they are not truly identical. I haven't compared the main images, but I suspect it's the same there.
- Support Windows (fix file path issues).
- Reduce .blend file sizes by enabling compression.
- Fix a small bug.

Based partially on the other forks: thanks [phonhay103](https://github.com/phonhay103/doc3D-renderer) and [xjiangan](https://github.com/xjiangan/doc3D-renderer).